### PR TITLE
Feature/async image fetching v1.3

### DIFF
--- a/FlixCombine.xcodeproj/project.pbxproj
+++ b/FlixCombine.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		EDE0625424468B06000EDEB6 /* MoviesListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0625324468B06000EDEB6 /* MoviesListView.swift */; };
 		EDE0625724468B98000EDEB6 /* Movie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0625624468B98000EDEB6 /* Movie.swift */; };
 		EDE0625924468C85000EDEB6 /* MoviesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0625824468C85000EDEB6 /* MoviesListViewModel.swift */; };
+		EDFA85742447E3BD0009EE80 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA85732447E3BC0009EE80 /* ImageLoader.swift */; };
+		EDFA85762447E3E70009EE80 /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA85752447E3E70009EE80 /* AsyncImage.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -32,6 +34,8 @@
 		EDE0625324468B06000EDEB6 /* MoviesListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesListView.swift; sourceTree = "<group>"; };
 		EDE0625624468B98000EDEB6 /* Movie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Movie.swift; sourceTree = "<group>"; };
 		EDE0625824468C85000EDEB6 /* MoviesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesListViewModel.swift; sourceTree = "<group>"; };
+		EDFA85732447E3BC0009EE80 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
+		EDFA85752447E3E70009EE80 /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -98,6 +102,7 @@
 			children = (
 				EDE0625324468B06000EDEB6 /* MoviesListView.swift */,
 				ED376CE32447BB3E00F0EA7E /* MovieRow.swift */,
+				EDFA85752447E3E70009EE80 /* AsyncImage.swift */,
 			);
 			path = View;
 			sourceTree = "<group>";
@@ -106,6 +111,7 @@
 			isa = PBXGroup;
 			children = (
 				EDE0624E2446443C000EDEB6 /* API.swift */,
+				EDFA85732447E3BC0009EE80 /* ImageLoader.swift */,
 			);
 			name = Network;
 			path = "New Group";
@@ -192,11 +198,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				EDE0625424468B06000EDEB6 /* MoviesListView.swift in Sources */,
+				EDFA85762447E3E70009EE80 /* AsyncImage.swift in Sources */,
 				EDE0623B244630FC000EDEB6 /* AppDelegate.swift in Sources */,
 				EDE0623D244630FC000EDEB6 /* SceneDelegate.swift in Sources */,
 				EDE0625924468C85000EDEB6 /* MoviesListViewModel.swift in Sources */,
 				ED376CE42447BB3E00F0EA7E /* MovieRow.swift in Sources */,
 				EDE0624F2446443C000EDEB6 /* API.swift in Sources */,
+				EDFA85742447E3BD0009EE80 /* ImageLoader.swift in Sources */,
 				EDE0625724468B98000EDEB6 /* Movie.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FlixCombine.xcodeproj/project.pbxproj
+++ b/FlixCombine.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		EDE0625924468C85000EDEB6 /* MoviesListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDE0625824468C85000EDEB6 /* MoviesListViewModel.swift */; };
 		EDFA85742447E3BD0009EE80 /* ImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA85732447E3BC0009EE80 /* ImageLoader.swift */; };
 		EDFA85762447E3E70009EE80 /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA85752447E3E70009EE80 /* AsyncImage.swift */; };
+		EDFA85782447F83E0009EE80 /* MovieRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDFA85772447F83E0009EE80 /* MovieRowViewModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +37,7 @@
 		EDE0625824468C85000EDEB6 /* MoviesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoviesListViewModel.swift; sourceTree = "<group>"; };
 		EDFA85732447E3BC0009EE80 /* ImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageLoader.swift; sourceTree = "<group>"; };
 		EDFA85752447E3E70009EE80 /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
+		EDFA85772447F83E0009EE80 /* MovieRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MovieRowViewModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -122,6 +124,7 @@
 			children = (
 				EDE0625624468B98000EDEB6 /* Movie.swift */,
 				EDE0625824468C85000EDEB6 /* MoviesListViewModel.swift */,
+				EDFA85772447F83E0009EE80 /* MovieRowViewModel.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -197,6 +200,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EDFA85782447F83E0009EE80 /* MovieRowViewModel.swift in Sources */,
 				EDE0625424468B06000EDEB6 /* MoviesListView.swift in Sources */,
 				EDFA85762447E3E70009EE80 /* AsyncImage.swift in Sources */,
 				EDE0623B244630FC000EDEB6 /* AppDelegate.swift in Sources */,

--- a/FlixCombine/App/SceneDelegate.swift
+++ b/FlixCombine/App/SceneDelegate.swift
@@ -21,7 +21,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
         // Create the SwiftUI view that provides the window contents.
         let viewModel = MoviesListViewModel()
-        let rootView = MoviesListView(model: viewModel)
+        let rootView = MoviesListView(viewModel)
 
         // Use a UIHostingController as window root view controller.
         if let windowScene = scene as? UIWindowScene {

--- a/FlixCombine/Model/MovieRowViewModel.swift
+++ b/FlixCombine/Model/MovieRowViewModel.swift
@@ -1,0 +1,27 @@
+//
+//  MovieRowViewModel.swift
+//  FlixCombine
+//
+//  Created by Charles Hieger on 4/15/20.
+//  Copyright © 2020 Charles Hieger. All rights reserved.
+//
+
+import Foundation
+
+class MovieRowViewModel: ObservableObject {
+
+    @Published var title: String
+    @Published var overview: String
+
+    private let posterPath: String?
+    var posterURL: URL? {
+        guard let posterPath = posterPath else { return nil }
+        return API.EndPoint.image(posterPath).url
+    }
+
+    init(_ movie: Movie) {
+        title = movie.title
+        overview = movie.overview
+        posterPath = movie.posterPath
+    }
+}

--- a/FlixCombine/New Group/API.swift
+++ b/FlixCombine/New Group/API.swift
@@ -28,10 +28,16 @@ struct API {
     enum EndPoint {
 
         case nowPlaying
+        case image(String)
 
         /// Query parameters needed for authentication, in this case, the api key.
         private var authenticationQueryParameters: [String: String?]? {
-            return ["api_key": "3fc4c235756257eca55e964b82f1a1a6"]
+            switch self {
+            case .nowPlaying:
+                return ["api_key": "3fc4c235756257eca55e964b82f1a1a6"]
+            case .image:
+                return nil
+            }
         }
 
         /// The path for the specified endpoint.
@@ -39,6 +45,18 @@ struct API {
             switch self {
             case .nowPlaying:
                 return "/3/movie/now_playing"
+            case .image(let url):
+                return "/t/p/w300" + url
+            }
+        }
+
+        /// The host for the specified endpoint. Images have a different host than fetching movies.
+        private var host: String {
+            switch self {
+            case .image:
+                return "image.tmdb.org"
+            default:
+                return "api.themoviedb.org"
             }
         }
 
@@ -46,7 +64,7 @@ struct API {
         var url: URL {
             var components = URLComponents()
             components.scheme = "https"
-            components.host = "api.themoviedb.org"
+            components.host = host
             components.path = path
             components.addQueryItems(with: authenticationQueryParameters)
             let url = components.url!

--- a/FlixCombine/New Group/ImageLoader.swift
+++ b/FlixCombine/New Group/ImageLoader.swift
@@ -7,3 +7,38 @@
 //
 
 import Foundation
+import Combine
+import SwiftUI
+
+class ImageLoader: ObservableObject {
+
+    /// The loaded image if available, otherwise nil.
+    @Published var image: UIImage?
+
+    /// The URL to fetch the image from.
+    private let url: URL
+
+    private var subscription: AnyCancellable?
+
+    init(url: URL) {
+        self.url = url
+    }
+
+    deinit {
+        subscription?.cancel()
+    }
+
+    func load() {
+        subscription = URLSession.shared
+            .dataTaskPublisher(for: url)
+            .print("🖼🐞 DEBUG IMAGE LOAD")
+            .map { UIImage(data: $0.data) }
+            .replaceError(with: nil)
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.image, on: self)
+    }
+
+    func cancel() {
+        subscription?.cancel()
+    }
+}

--- a/FlixCombine/New Group/ImageLoader.swift
+++ b/FlixCombine/New Group/ImageLoader.swift
@@ -1,0 +1,9 @@
+//
+//  ImageLoader.swift
+//  FlixCombine
+//
+//  Created by Charles Hieger on 4/15/20.
+//  Copyright © 2020 Charles Hieger. All rights reserved.
+//
+
+import Foundation

--- a/FlixCombine/View/AsyncImage.swift
+++ b/FlixCombine/View/AsyncImage.swift
@@ -8,14 +8,43 @@
 
 import SwiftUI
 
-struct AsyncImage: View {
+struct AsyncImage<Placeholder: View>: View {
+
+    @ObservedObject private var loader: ImageLoader
+
+    /// The optional placeholder view to show when image is nil.
+    private let placeholder: Placeholder?
+
+    init(url: URL, placeholder: Placeholder? = nil) {
+        loader = ImageLoader(url: url)
+        self.placeholder = placeholder
+
+        // Kick off image loading.
+        loader.load()
+    }
+
+    /// The fetched image to show if available, otherwise show placeholder.
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Group {
+            if loader.image != nil {
+                Image(uiImage: loader.image!)
+                    .resizable()
+            } else {
+                placeholder
+            }
+        }
     }
 }
 
+#if DEBUG
 struct AsyncImage_Previews: PreviewProvider {
     static var previews: some View {
-        AsyncImage()
+        AsyncImage(
+            url: URL(string: "https://image.tmdb.org/t/p/w500/kqjL17yufvn9OVLyXYpvtyrFfak.jpg")!,
+            placeholder: Image(systemName: "film")
+                .resizable()
+                .frame(width: 80, height: 80)
+        )
     }
 }
+#endif

--- a/FlixCombine/View/AsyncImage.swift
+++ b/FlixCombine/View/AsyncImage.swift
@@ -1,0 +1,21 @@
+//
+//  AsyncImage.swift
+//  FlixCombine
+//
+//  Created by Charles Hieger on 4/15/20.
+//  Copyright © 2020 Charles Hieger. All rights reserved.
+//
+
+import SwiftUI
+
+struct AsyncImage: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct AsyncImage_Previews: PreviewProvider {
+    static var previews: some View {
+        AsyncImage()
+    }
+}

--- a/FlixCombine/View/MovieRow.swift
+++ b/FlixCombine/View/MovieRow.swift
@@ -9,37 +9,50 @@
 import SwiftUI
 
 struct MovieRow: View {
-    let title: String
-    let overview: String
 
-    init(title: String, overview: String) {
-        self.title = title
-        self.overview = overview
+    @ObservedObject var model: MovieRowViewModel
+
+    init(_ model: MovieRowViewModel) {
+        self.model = model
     }
 
     var body: some View {
         HStack(alignment: .top) {
-            Image(systemName: "film")
-                .resizable()
-                .frame(width: 80, height: 80)
+            Group {
+                if model.posterURL != nil {
+                    AsyncImage(
+                        url: model.posterURL!,
+                        placeholder: Image(systemName: "film")
+                            .resizable()
+                    )
+                    .aspectRatio(contentMode: .fill)
+                } else {
+                    // Default image if unable to fetch poster url.
+                    Image(systemName: "film")
+                    .resizable()
+                }
+            }
+            .frame(width: 100, height: 150)
+            .clipped(antialiased: true)
             VStack(alignment: .leading) {
-                Text(title)
+                Text(model.title)
                     .font(.title)
                     .lineLimit(2)
                     .minimumScaleFactor(0.6)
-                Text(overview)
+                Text(model.overview)
                     .font(.caption)
-                    .lineLimit(4)
+                    .lineLimit(5)
             }
         }
     }
 }
 
-#if DEBUG
-struct MovieRow_Previews: PreviewProvider {
-    static var previews: some View {
-        MovieRow(title: "Kamen Rider Reiwa: The First Generation",
-                 overview: "Queen Poppy and Branch make a surprising discovery — there are other Troll worlds beyond their own, and their distinct differences create big clashes between these various tribes. When a mysterious threat puts all of the Trolls across the land in danger, Poppy, Branch, and their band of friends must embark on an epic quest to create harmony among the feuding Trolls to unite them against certain doom.")
-    }
-}
-#endif
+//#if DEBUG
+//struct MovieRow_Previews: PreviewProvider {
+//    static var previews: some View {
+//        MovieRow(title: "Kamen Rider Reiwa: The First Generation",
+//                 overview: "Queen Poppy and Branch make a surprising discovery — there are other Troll worlds beyond their own, and their distinct differences create big clashes between these various tribes. When a mysterious threat puts all of the Trolls across the land in danger, Poppy, Branch, and their band of friends must embark on an epic quest to create harmony among the feuding Trolls to unite them against certain doom.",
+//                 posterURL: URL(string: "https://image.tmdb.org/t/p/w500/8uO0gUM8aNqYLs1OsTBQiXu0fEv.jpg")!)
+//    }
+//}
+//#endif

--- a/FlixCombine/View/MoviesListView.swift
+++ b/FlixCombine/View/MoviesListView.swift
@@ -21,8 +21,7 @@ struct MoviesListView: View {
             List {
                 Section(header: Text("Now Playing")) {
                     ForEach(self.model.movies) { movie in
-                        MovieRow(title: movie.title,
-                                 overview: movie.overview)
+                        MovieRow(MovieRowViewModel(movie))
                     }
                 }
             }

--- a/FlixCombine/View/MoviesListView.swift
+++ b/FlixCombine/View/MoviesListView.swift
@@ -11,7 +11,7 @@ import SwiftUI
 struct MoviesListView: View {
     @ObservedObject var model: MoviesListViewModel
 
-    init(model: MoviesListViewModel) {
+    init(_ model: MoviesListViewModel) {
         self.model = model
     }
 

--- a/FlixCombine/View/MoviesListView.swift
+++ b/FlixCombine/View/MoviesListView.swift
@@ -34,7 +34,7 @@ struct MoviesListView: View {
 #if DEBUG
 struct MoviesListView_Previews: PreviewProvider {
     static var previews: some View {
-        MoviesListView(model: MoviesListViewModel())
+        MoviesListView(MoviesListViewModel())
     }
 }
 #endif


### PR DESCRIPTION
## Display movie poster images
### Goal
Fetch movie poster images asynchronously and display in movie rows.

### Steps
1. Create ImageLoader class.
   1. Observable Object with `@Published` image property.
1. Create Custom AsyncImage view that utilizes ImageLoader.
   1. Add property for ImageLoader with `ObservedObject` wrapper to observe when image updates.
   1. Takes an optional Placeholder of type `View`. This allows the caller to pass in any view for placeholder, for instance placeholder could be Text vs. Image.
1. Update API with Endpoint to fetch images.
   1. Image fetching url has different `host` as well as `path`.
1. Create MovieRowViewModel initialized my a movie object.
   1. Add computed property for image url.
   1. Update MovieListView to initialize MovieRow with in MovieRowViewModel.

### Images
![flix_1 3](https://user-images.githubusercontent.com/11927517/79494526-031b3680-7fd8-11ea-813b-eea89e7c7930.gif)


